### PR TITLE
Basic c++ code improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,4 +41,3 @@ after_build:
 
 artifacts:
   - path: build\%artifactName%
-  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 os:
-  - Visual Studio 2015
+  - Visual Studio 2019
   
 platform: x64
   

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,8 @@
 os:
   - Visual Studio 2019
-  
+
 platform: x64
-  
+
 branches:
   only:
     - master
@@ -16,13 +16,13 @@ build:
 
 configuration:
   - Release
-  
+
 environment:
   artifactName: $(APPVEYOR_PROJECT_NAME)-$(APPVEYOR_REPO_COMMIT)-$(CONFIGURATION)
   matrix:
     - env_arch: "x64"
     - env_arch: "x86"
-  
+
 before_build:
   - mkdir build
   - cd build
@@ -31,10 +31,10 @@ before_build:
   - if [%env_arch%]==[x86] (
     cmake .. )
   - cmake -DCMAKE_INSTALL_PREFIX:PATH=%APPVEYOR_BUILD_FOLDER%/%APPVEYOR_REPO_COMMIT% ..
-  
+
 build_script:
   - cmake --build . --config %CONFIGURATION% --target install
-  
+
 after_build:
   - mkdir %artifactName%
   - cp %APPVEYOR_BUILD_FOLDER%/%APPVEYOR_REPO_COMMIT%/* %artifactName%

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 2.8 )
+cmake_minimum_required ( VERSION 3.0 )
 
 project ( masm_shc )
 

--- a/demos/knock.cpp
+++ b/demos/knock.cpp
@@ -5,55 +5,23 @@
 
 typedef struct
 {
-    HMODULE(WINAPI * _LoadLibraryA)(LPCSTR lpLibFileName);
-    FARPROC(WINAPI * _GetProcAddress)(HMODULE hModule, LPCSTR lpProcName);
+    decltype(&LoadLibraryA) _LoadLibraryA;
+    decltype(&GetProcAddress) _GetProcAddress;
 } t_mini_iat;
 
 typedef struct
 {
-    int (PASCAL FAR *_WSAStartup)(
-        _In_ WORD wVersionRequired,
-        _Out_ LPWSADATA lpWSAData);
-
-    SOCKET(PASCAL FAR *_socket)(
-        _In_ int af,
-        _In_ int type,
-        _In_ int protocol);
-
-    unsigned long (PASCAL FAR *_inet_addr)(_In_z_ const char FAR * cp);
-
-    int (PASCAL FAR *_bind)(
-        _In_ SOCKET s,
-        _In_reads_bytes_(namelen) const struct sockaddr FAR *addr,
-        _In_ int namelen);
-
-    int (PASCAL FAR *_listen)(
-        _In_ SOCKET s,
-        _In_ int backlog);
-
-    SOCKET(PASCAL FAR *_accept)(
-        _In_ SOCKET s,
-        _Out_writes_bytes_opt_(*addrlen) struct sockaddr FAR *addr,
-        _Inout_opt_ int FAR *addrlen);
-
-    int (PASCAL FAR *_recv)(
-        _In_ SOCKET s,
-        _Out_writes_bytes_to_(len, return) __out_data_source(NETWORK) char FAR * buf,
-        _In_ int len,
-        _In_ int flags);
-
-    int (PASCAL FAR *_send)(
-        _In_ SOCKET s,
-        _In_reads_bytes_(len) const char FAR * buf,
-        _In_ int len,
-        _In_ int flags);
-
-    int (PASCAL FAR *_closesocket)(IN SOCKET s);
-
-    u_short(PASCAL FAR *_htons)(_In_ u_short hostshort);
-
-    int (PASCAL FAR *_WSACleanup)(void);
-
+    decltype(&WSAStartup) _WSAStartup;
+    decltype(&socket) _socket;
+    decltype(&inet_addr) _inet_addr;
+    decltype(&bind) _bind;
+    decltype(&listen) _listen;
+    decltype(&accept) _accept;
+    decltype(&recv) _recv;
+    decltype(&send) _send;
+    decltype(&closesocket) _closesocket;
+    decltype(&htons) _htons;
+    decltype(&WSACleanup) _WSACleanup;
 } t_socket_iat;
 
 
@@ -73,8 +41,8 @@ bool init_iat(t_mini_iat &iat)
         return false;
     }
 
-    iat._LoadLibraryA = (HMODULE(WINAPI*)(LPCSTR)) load_lib;
-    iat._GetProcAddress = (FARPROC(WINAPI*)(HMODULE, LPCSTR)) get_proc;
+    iat._LoadLibraryA = reinterpret_cast<decltype(&LoadLibraryA)>(load_lib);
+    iat._GetProcAddress = reinterpret_cast<decltype(&GetProcAddress)>(get_proc);
     return true;
 }
 
@@ -82,53 +50,17 @@ bool init_socket_iat(t_mini_iat &iat, t_socket_iat &sIAT)
 {
     LPVOID WS232_dll = iat._LoadLibraryA("WS2_32.dll");
 
-    sIAT._WSAStartup = (int (PASCAL FAR *)(
-        _In_ WORD,
-        _Out_ LPWSADATA)) iat._GetProcAddress((HMODULE)WS232_dll, "WSAStartup");
-
-    sIAT._socket = (SOCKET(PASCAL FAR *)(
-        _In_ int af,
-        _In_ int type,
-        _In_ int protocol)) iat._GetProcAddress((HMODULE)WS232_dll, "socket");
-
-    sIAT._inet_addr
-        = (unsigned long (PASCAL FAR *)(_In_z_ const char FAR * cp))
-        iat._GetProcAddress((HMODULE)WS232_dll, "inet_addr");
-
-    sIAT._bind = (int (PASCAL FAR *)(
-        _In_ SOCKET s,
-        _In_reads_bytes_(namelen) const struct sockaddr FAR *addr,
-        _In_ int namelen)) iat._GetProcAddress((HMODULE)WS232_dll, "bind");
-
-    sIAT._listen = (int (PASCAL FAR *)(
-        _In_ SOCKET s,
-        _In_ int backlog)) iat._GetProcAddress((HMODULE)WS232_dll, "listen");
-
-    sIAT._accept = (SOCKET(PASCAL FAR *)(
-        _In_ SOCKET s,
-        _Out_writes_bytes_opt_(*addrlen) struct sockaddr FAR *addr,
-        _Inout_opt_ int FAR *addrlen)) iat._GetProcAddress((HMODULE)WS232_dll, "accept"); ;
-
-    sIAT._recv = (int (PASCAL FAR *)(
-        _In_ SOCKET s,
-        _Out_writes_bytes_to_(len, return) __out_data_source(NETWORK) char FAR * buf,
-        _In_ int len,
-        _In_ int flags)) iat._GetProcAddress((HMODULE)WS232_dll, "recv"); ;
-
-    sIAT._send = (int (PASCAL FAR *)(
-        _In_ SOCKET s,
-        _In_reads_bytes_(len) const char FAR * buf,
-        _In_ int len,
-        _In_ int flags)) iat._GetProcAddress((HMODULE)WS232_dll, "send");
-
-    sIAT._closesocket
-        = (int (PASCAL FAR *)(IN SOCKET s)) iat._GetProcAddress((HMODULE)WS232_dll, "closesocket");
-
-    sIAT._htons
-        = (u_short(PASCAL FAR *)(_In_ u_short hostshort)) iat._GetProcAddress((HMODULE)WS232_dll, "htons");
-
-    sIAT._WSACleanup
-        = (int (PASCAL FAR *)(void)) iat._GetProcAddress((HMODULE)WS232_dll, "WSACleanup");
+    sIAT._WSAStartup = reinterpret_cast<decltype(&WSAStartup)>(iat._GetProcAddress((HMODULE)WS232_dll, "WSAStartup"));
+    sIAT._socket = reinterpret_cast<decltype(&socket)>(iat._GetProcAddress((HMODULE)WS232_dll, "socket"));
+    sIAT._inet_addr = reinterpret_cast<decltype(&inet_addr)>(iat._GetProcAddress((HMODULE)WS232_dll, "inet_addr"));
+    sIAT._bind = reinterpret_cast<decltype(&bind)>(iat._GetProcAddress((HMODULE)WS232_dll, "bind"));
+    sIAT._listen = reinterpret_cast<decltype(&listen)>(iat._GetProcAddress((HMODULE)WS232_dll, "listen"));
+    sIAT._accept = reinterpret_cast<decltype(&accept)>(iat._GetProcAddress((HMODULE)WS232_dll, "accept"));
+    sIAT._recv = reinterpret_cast<decltype(&recv)>(iat._GetProcAddress((HMODULE)WS232_dll, "recv"));
+    sIAT._send = reinterpret_cast<decltype(&send)>(iat._GetProcAddress((HMODULE)WS232_dll, "send"));
+    sIAT._closesocket = reinterpret_cast<decltype(&closesocket)>(iat._GetProcAddress((HMODULE)WS232_dll, "closesocket"));
+    sIAT._htons = reinterpret_cast<decltype(&htons)>(iat._GetProcAddress((HMODULE)WS232_dll, "htons"));
+    sIAT._WSACleanup = reinterpret_cast<decltype(&WSACleanup)>(iat._GetProcAddress((HMODULE)WS232_dll, "WSACleanup"));
 
     return true;
 }
@@ -180,15 +112,7 @@ bool listen_for_connect(t_mini_iat &iat, int port, char resp[4])
     LPVOID u32_dll = iat._LoadLibraryA("user32.dll");
 
 
-    int (WINAPI * _MessageBoxW)(
-        _In_opt_ HWND hWnd,
-        _In_opt_ LPCWSTR lpText,
-        _In_opt_ LPCWSTR lpCaption,
-        _In_ UINT uType) = (int (WINAPI*)(
-            _In_opt_ HWND,
-            _In_opt_ LPCWSTR,
-            _In_opt_ LPCWSTR,
-            _In_ UINT)) iat._GetProcAddress((HMODULE)u32_dll, "MessageBoxW");
+    auto _MessageBoxW = reinterpret_cast<decltype(&MessageBoxW)>(iat._GetProcAddress((HMODULE)u32_dll, "MessageBoxW"));
 
     bool got_resp = false;
     WSADATA wsaData;
@@ -199,8 +123,8 @@ bool listen_for_connect(t_mini_iat &iat, int port, char resp[4])
     }
     struct sockaddr_in sock_config;
     SecureZeroMemory(&sock_config, sizeof(sock_config));
-    SOCKET listen_socket = 0;
-    if ((listen_socket = sIAT._socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == INVALID_SOCKET) {
+    SOCKET listen_socket = sIAT._socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (listen_socket == INVALID_SOCKET) {
         _MessageBoxW(NULL, L"Creating the socket failed", L"Stage 2", MB_ICONEXCLAMATION);
         sIAT._WSACleanup();
         return false;

--- a/demos/knock_test.py
+++ b/demos/knock_test.py
@@ -8,7 +8,7 @@ def main():
     parser.add_argument('--buf', dest="buf", default="0", help="Buffer to send")
     args = parser.parse_args()
     my_port = int(args.port, 10)
-    print '[+] Connecting to port: ' + hex(my_port)
+    print('[+] Connecting to port: ' + hex(my_port))
     key = args.buf
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -16,11 +16,10 @@ def main():
         s.send(key)
         result = s.recv(512)
         if result is not None:
-            print "[+] Response: " + result
+            print("[+] Response: " + str(result))
         s.close()
     except socket.error:
-        print "Could not connect to the socket. Is the crackme running?"
-    
+        print("Could not connect to the socket. Is the crackme running?")
+
 if __name__ == "__main__":
     sys.exit(main())
-	

--- a/demos/knock_test.py
+++ b/demos/knock_test.py
@@ -2,6 +2,7 @@ import socket
 import sys
 import argparse
 
+
 def main():
     parser = argparse.ArgumentParser(description="Send to the Crackme")
     parser.add_argument('--port', dest="port", default="1337", help="Port to connect")
@@ -20,6 +21,7 @@ def main():
         s.close()
     except socket.error:
         print("Could not connect to the socket. Is the crackme running?")
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/demos/knock_test.py
+++ b/demos/knock_test.py
@@ -9,7 +9,7 @@ def main():
     parser.add_argument('--buf', dest="buf", default="0", help="Buffer to send")
     args = parser.parse_args()
     my_port = int(args.port, 10)
-    print('[+] Connecting to port: ' + hex(my_port))
+    print('[+] Connecting to port: ' + str(my_port))
     key = args.buf
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/demos/knock_test.py
+++ b/demos/knock_test.py
@@ -6,7 +6,7 @@ import argparse
 def main():
     parser = argparse.ArgumentParser(description="Send to the Crackme")
     parser.add_argument('--port', dest="port", default="1337", help="Port to connect")
-    parser.add_argument('--buf', dest="buf", default=b"0", help="Buffer to send")
+    parser.add_argument('--buf', dest="buf", default=b"9", help="Buffer to send")
     args = parser.parse_args()
     my_port = int(args.port)
     print('[+] Connecting to port: ' + str(my_port))

--- a/demos/knock_test.py
+++ b/demos/knock_test.py
@@ -8,7 +8,7 @@ def main():
     parser.add_argument('--port', dest="port", default="1337", help="Port to connect")
     parser.add_argument('--buf', dest="buf", default="0", help="Buffer to send")
     args = parser.parse_args()
-    my_port = int(args.port, 10)
+    my_port = int(args.port)
     print('[+] Connecting to port: ' + str(my_port))
     key = args.buf
     try:

--- a/demos/knock_test.py
+++ b/demos/knock_test.py
@@ -6,11 +6,11 @@ import argparse
 def main():
     parser = argparse.ArgumentParser(description="Send to the Crackme")
     parser.add_argument('--port', dest="port", default="1337", help="Port to connect")
-    parser.add_argument('--buf', dest="buf", default=b"9", help="Buffer to send")
+    parser.add_argument('--buf', dest="buf", default="9", help="Buffer to send")
     args = parser.parse_args()
     my_port = int(args.port)
     print('[+] Connecting to port: ' + str(my_port))
-    key = args.buf
+    key = args.buf.encode()
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect(('127.0.0.1', my_port))

--- a/demos/knock_test.py
+++ b/demos/knock_test.py
@@ -24,4 +24,7 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/demos/knock_test.py
+++ b/demos/knock_test.py
@@ -6,7 +6,7 @@ import argparse
 def main():
     parser = argparse.ArgumentParser(description="Send to the Crackme")
     parser.add_argument('--port', dest="port", default="1337", help="Port to connect")
-    parser.add_argument('--buf', dest="buf", default="0", help="Buffer to send")
+    parser.add_argument('--buf', dest="buf", default=b"0", help="Buffer to send")
     args = parser.parse_args()
     my_port = int(args.port)
     print('[+] Connecting to port: ' + str(my_port))

--- a/demos/peb_lookup.h
+++ b/demos/peb_lookup.h
@@ -45,12 +45,12 @@ inline LPVOID get_func_by_name(LPVOID module, char* func_name)
 {
     IMAGE_DOS_HEADER* idh = (IMAGE_DOS_HEADER*)module;
     if (idh->e_magic != IMAGE_DOS_SIGNATURE) {
-        return NULL;
+        return nullptr;
     }
     IMAGE_NT_HEADERS* nt_headers = (IMAGE_NT_HEADERS*)((BYTE*)module + idh->e_lfanew);
     IMAGE_DATA_DIRECTORY* exportsDir = &(nt_headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT]);
-    if (exportsDir->VirtualAddress == NULL) {
-        return NULL;
+    if (!exportsDir->VirtualAddress) {
+        return nullptr;
     }
 
     DWORD expAddr = exportsDir->VirtualAddress;
@@ -77,5 +77,5 @@ inline LPVOID get_func_by_name(LPVOID module, char* func_name)
             return (BYTE*)module + (*funcRVA);
         }
     }
-    return NULL;
+    return nullptr;
 }

--- a/demos/peb_lookup.h
+++ b/demos/peb_lookup.h
@@ -1,104 +1,44 @@
 #pragma once
-#include <Windows.h>
 
-#ifndef __NTDLL_H__
+#include <windows.h>
+#include <winternl.h>
 
 #ifndef TO_LOWERCASE
 #define TO_LOWERCASE(out, c1) (out = (c1 <= 'Z' && c1 >= 'A') ? c1 = (c1 - 'A') + 'a': c1)
 #endif
 
-
-typedef struct _UNICODE_STRING
-{
-    USHORT Length;
-    USHORT MaximumLength;
-    PWSTR  Buffer;
-
-} UNICODE_STRING, * PUNICODE_STRING;
-
-typedef struct _PEB_LDR_DATA
-{
-    ULONG Length;
-    BOOLEAN Initialized;
-    HANDLE SsHandle;
-    LIST_ENTRY InLoadOrderModuleList;      
-    LIST_ENTRY InMemoryOrderModuleList;        
-    LIST_ENTRY InInitializationOrderModuleList;
-    PVOID      EntryInProgress;
-
-} PEB_LDR_DATA, * PPEB_LDR_DATA;
-
-//here we don't want to use any functions imported form extenal modules
-
-typedef struct _LDR_DATA_TABLE_ENTRY {
-    LIST_ENTRY  InLoadOrderModuleList;
-    LIST_ENTRY  InMemoryOrderModuleList;
-    LIST_ENTRY  InInitializationOrderModuleList;
-    void* BaseAddress; 
-    void* EntryPoint; 
-    ULONG   SizeOfImage;
-    UNICODE_STRING FullDllName;
-    UNICODE_STRING BaseDllName;
-    ULONG   Flags;
-    SHORT   LoadCount;
-    SHORT   TlsIndex;
-    HANDLE  SectionHandle;
-    ULONG   CheckSum;
-    ULONG   TimeDateStamp;
-} LDR_DATA_TABLE_ENTRY, * PLDR_DATA_TABLE_ENTRY;
-
-
-typedef struct _PEB
-{
-    BOOLEAN InheritedAddressSpace;      
-    BOOLEAN ReadImageFileExecOptions;  
-    BOOLEAN BeingDebugged;             
-    BOOLEAN SpareBool;                 
-    HANDLE Mutant;                     
-
-    PVOID ImageBaseAddress;
-    PPEB_LDR_DATA Ldr;
-
-    // [...] this is a fragment, more elements follow here
-
-} PEB, * PPEB;
-
-#endif //__NTDLL_H__
-
 inline LPVOID get_module_by_name(WCHAR* module_name)
 {
-    PPEB peb = NULL;
+    //FIXME
+    //PEB *peb = NtCurrentTeb()->ProcessEnvironmentBlock;
+    PEB *peb;
 #if defined(_WIN64)
     peb = (PPEB)__readgsqword(0x60);
 #else
     peb = (PPEB)__readfsdword(0x30);
 #endif
-    PPEB_LDR_DATA ldr = peb->Ldr;
-    LIST_ENTRY list = ldr->InLoadOrderModuleList;
+    PEB_LDR_DATA *ldr = peb->Ldr;
 
-    PLDR_DATA_TABLE_ENTRY Flink = *((PLDR_DATA_TABLE_ENTRY*)(&list));
-    PLDR_DATA_TABLE_ENTRY curr_module = Flink;
+    LIST_ENTRY *head = &ldr->InMemoryOrderModuleList;
+    for(LIST_ENTRY *current = head->Flink; current != head; current = current->Flink){
+        LDR_DATA_TABLE_ENTRY *entry = CONTAINING_RECORD(current, LDR_DATA_TABLE_ENTRY, InMemoryOrderLinks);
 
-    while (curr_module != NULL && curr_module->BaseAddress != NULL) {
-        if (curr_module->BaseDllName.Buffer) {
-            WCHAR* curr_name = curr_module->BaseDllName.Buffer;
+        UNICODE_STRING *dllName = (&entry->FullDllName) + 1; //hack to access BaseDllName field
+        WCHAR *curr_name = dllName->Buffer;
 
-            size_t i = 0;
-            for (i = 0; module_name[i] != 0 && curr_name[i] != 0; i++) {
-                WCHAR c1, c2;
-                TO_LOWERCASE(c1, module_name[i]);
-                TO_LOWERCASE(c2, curr_name[i]);
-                if (c1 != c2) break;
-            }
-            if (module_name[i] == 0 && curr_name[i] == 0) {
-                //found
-                return curr_module->BaseAddress;
-            }
+        size_t i;
+        for (i = 0; module_name[i] != 0 && curr_name[i] != 0; i++) {
+            WCHAR c1, c2;
+            TO_LOWERCASE(c1, module_name[i]);
+            TO_LOWERCASE(c2, curr_name[i]);
+            if (c1 != c2) break;
         }
-        // not found, try next:
-        curr_module = (PLDR_DATA_TABLE_ENTRY)curr_module->InLoadOrderModuleList.Flink;
+        if (module_name[i] == 0 && curr_name[i] == 0) {
+            return entry->DllBase;
+        }
     }
-    return NULL;
+
+    return nullptr;
 }
 
 inline LPVOID get_func_by_name(LPVOID module, char* func_name)
@@ -128,7 +68,7 @@ inline LPVOID get_func_by_name(LPVOID module, char* func_name)
         DWORD* funcRVA = (DWORD*)(funcsListRVA + (BYTE*)module + (*nameIndex) * sizeof(DWORD));
 
         LPSTR curr_name = (LPSTR)(*nameRVA + (BYTE*)module);
-        size_t k = 0;
+        size_t k;
         for (k = 0; func_name[k] != 0 && curr_name[k] != 0; k++) {
             if (func_name[k] != curr_name[k]) break;
         }

--- a/demos/popup.cpp
+++ b/demos/popup.cpp
@@ -16,23 +16,13 @@ int main()
     if (!get_proc) {
         return 3;
     }
-    HMODULE(WINAPI * _LoadLibraryA)(LPCSTR lpLibFileName) = (HMODULE(WINAPI*)(LPCSTR))load_lib;
-    FARPROC(WINAPI * _GetProcAddress)(HMODULE hModule, LPCSTR lpProcName)
-        = (FARPROC(WINAPI*)(HMODULE, LPCSTR)) get_proc;
+    auto _LoadLibraryA = reinterpret_cast<decltype(&LoadLibraryA)>(load_lib);
+    auto _GetProcAddress = reinterpret_cast<decltype(&GetProcAddress)>(get_proc);
 
     LPVOID u32_dll = _LoadLibraryA("user32.dll");
 
-    int (WINAPI * _MessageBoxW)(
-        _In_opt_ HWND hWnd,
-        _In_opt_ LPCWSTR lpText,
-        _In_opt_ LPCWSTR lpCaption,
-        _In_ UINT uType) = (int (WINAPI*)(
-            _In_opt_ HWND,
-            _In_opt_ LPCWSTR,
-            _In_opt_ LPCWSTR,
-            _In_ UINT)) _GetProcAddress((HMODULE)u32_dll, "MessageBoxW");
-
-    if (_MessageBoxW == NULL) return 4;
+    auto _MessageBoxW = reinterpret_cast<decltype(&MessageBoxW)>(_GetProcAddress((HMODULE)u32_dll, "MessageBoxW"));
+    if (!_MessageBoxW) return 4;
 
     _MessageBoxW(0, L"Hello World!", L"Demo!", MB_OK);
 

--- a/demos/popup_arr.cpp
+++ b/demos/popup_arr.cpp
@@ -16,26 +16,16 @@ int main()
     if (!get_proc) {
         return 3;
     }
-    HMODULE(WINAPI * _LoadLibraryA)(LPCSTR lpLibFileName) = (HMODULE(WINAPI*)(LPCSTR))load_lib;
-    FARPROC(WINAPI * _GetProcAddress)(HMODULE hModule, LPCSTR lpProcName)
-        = (FARPROC(WINAPI*)(HMODULE, LPCSTR)) get_proc;
+    auto _LoadLibraryA = reinterpret_cast<decltype(&LoadLibraryA)>(load_lib);
+    auto _GetProcAddress = reinterpret_cast<decltype(&GetProcAddress)>(get_proc);
 
     LPVOID u32_dll = _LoadLibraryA("user32.dll");
 
-    int (WINAPI * _MessageBoxW)(
-        _In_opt_ HWND hWnd,
-        _In_opt_ LPCWSTR lpText,
-        _In_opt_ LPCWSTR lpCaption,
-        _In_ UINT uType) = (int (WINAPI*)(
-            _In_opt_ HWND,
-            _In_opt_ LPCWSTR,
-            _In_opt_ LPCWSTR,
-            _In_ UINT)) _GetProcAddress((HMODULE)u32_dll, "MessageBoxW");
-
-    if (_MessageBoxW == NULL) return 4;
+    auto _MessageBoxW = reinterpret_cast<decltype(&MessageBoxW)>(_GetProcAddress((HMODULE)u32_dll, "MessageBoxW"));
+    if (!_MessageBoxW) return 4;
     
     wchar_t* temp[] = { L"123", L"xxx", L"bbb" };
-    for (size_t i = 0; i < _countof(temp); i++) {	
+    for (size_t i = 0; i < _countof(temp); i++) {
         _MessageBoxW(0, temp[i], L"Demo", MB_OK);
     }
     return 0;

--- a/masm_shc/CMakeLists.txt
+++ b/masm_shc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 project ( masm_shc )
 

--- a/masm_shc/string_util.cpp
+++ b/masm_shc/string_util.cpp
@@ -1,6 +1,6 @@
 #include "string_util.h"
 
-std::vector<std::string> split_by_delimiter(std::string line, char delim)
+std::vector<std::string> split_by_delimiter(const std::string& line, char delim)
 {
     std::string split;
     std::istringstream ss(line);
@@ -18,10 +18,10 @@ std::vector<std::string> split_by_delimiter(std::string line, char delim)
 size_t replace_char(std::string &str, const char from, const char to)
 {
     size_t replaced = 0;
-    for (size_t i = 0; i < str.length(); i++) {
-        const char c = str[i];
+    for (char &i: str) {
+        const char c = i;
         if (c == from) {
-            str[i] = to;
+            i = to;
             replaced++;
         }
     }
@@ -36,9 +36,9 @@ void remove_prefix(std::string &str, const std::string &prefix)
         str.erase(i, prefix.length());
 }
 
-void replace_str(std::string &my_str, const std::string from_str, const std::string to_str)
+void replace_str(std::string &my_str, const std::string& from_str, const std::string& to_str)
 {
-    int index;
+    size_t index;
     while ((index = my_str.find(from_str)) != std::string::npos) {
         my_str.replace(index, from_str.length(), to_str);
     }

--- a/masm_shc/string_util.h
+++ b/masm_shc/string_util.h
@@ -19,10 +19,10 @@ inline std::string& trim(std::string& s)
     return s;
 }
 
-std::vector<std::string> split_by_delimiter(std::string line, char delim);
+std::vector<std::string> split_by_delimiter(const std::string& line, char delim);
 
 size_t replace_char(std::string &str, const char from, const char to);
 
 void remove_prefix(std::string &str, const std::string &prefix);
 
-void replace_str(std::string &my_str, const std::string from_str, const std::string to_str);
+void replace_str(std::string &my_str, const std::string& from_str, const std::string& to_str);

--- a/runshc/CMakeLists.txt
+++ b/runshc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 project ( runshc )
 

--- a/runshc/main.cpp
+++ b/runshc/main.cpp
@@ -2,6 +2,8 @@
 #include <iostream>
 #include "util.h"
 
+int my_main_prototype();
+
 int main(int argc, char *argv[])
 {
     if (argc < 2) {
@@ -38,11 +40,10 @@ int main(int argc, char *argv[])
 
     //free the original buffer:
     util::free_file(my_exe);
-    my_exe = nullptr;
 
     std::cout << "[*] Running the shellcode:" << std::endl;
     //run it:
-    int(*my_main)() = (int(*)()) ((ULONGLONG)test_buf);
+    auto my_main = reinterpret_cast<decltype(&my_main_prototype)>(test_buf); //function pointer to my_main_prototype
     int ret_val = my_main();
 
     util::free_aligned(test_buf);

--- a/runshc/util.cpp
+++ b/runshc/util.cpp
@@ -3,7 +3,7 @@
 
 BYTE* util::alloc_aligned(size_t buffer_size, DWORD protect, ULONGLONG desired_base)
 {
-    if (!buffer_size) return NULL;
+    if (!buffer_size) return nullptr;
 
     BYTE* buf = (BYTE*)VirtualAlloc((LPVOID)desired_base, buffer_size, MEM_COMMIT | MEM_RESERVE, protect);
     return buf;
@@ -23,14 +23,14 @@ bool util::free_aligned(BYTE* buffer)
 
 BYTE* util::load_file(IN const char *filename, OUT size_t &read_size)
 {
-    HANDLE file = CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+    HANDLE file = CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (file == INVALID_HANDLE_VALUE) {
 #ifdef _DEBUG
         std::cerr << "Could not open file!" << std::endl;
 #endif
         return nullptr;
     }
-    HANDLE mapping = CreateFileMapping(file, 0, PAGE_READONLY, 0, 0, 0);
+    HANDLE mapping = CreateFileMappingA(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
     if (!mapping) {
 #ifdef _DEBUG
         std::cerr << "Could not create mapping!" << std::endl;
@@ -47,7 +47,7 @@ BYTE* util::load_file(IN const char *filename, OUT size_t &read_size)
         CloseHandle(file);
         return nullptr;
     }
-    size_t r_size = GetFileSize(file, 0);
+    size_t r_size = GetFileSize(file, nullptr);
     if (read_size != 0 && read_size <= r_size) {
         r_size = read_size;
     }


### PR DESCRIPTION
- function pointers replaced with `decltype(&funcname)`
- cmake min version is 3.0 now
- fixed clang-tidy warns
- knock_test upgraded to python 3
- appveyor uses visual studio 2019