### PR TITLE
Change "CONST" to "_DATA" to fix string inlining

### DIFF
--- a/masm_shc/main.cpp
+++ b/masm_shc/main.cpp
@@ -154,7 +154,7 @@ bool process_file(t_params &params)
             if (seg_name == "pdata" || seg_name == "xdata") {
                 in_skipped = true;
             }
-            if (seg_name == "_DATA") {
+            if (seg_name == "CONST" || seg_name == "_DATA") {
                 in_const = true;
             }
             if (tokens[1] == "ENDS" && tokens[0] == seg_name) {

--- a/masm_shc/main.cpp
+++ b/masm_shc/main.cpp
@@ -154,7 +154,7 @@ bool process_file(t_params &params)
             if (seg_name == "pdata" || seg_name == "xdata") {
                 in_skipped = true;
             }
-            if (seg_name == "CONST") {
+            if (seg_name == "_DATA") {
                 in_const = true;
             }
             if (tokens[1] == "ENDS" && tokens[0] == seg_name) {


### PR DESCRIPTION
I'm not sure if it's because of the version of VS I'm using (VS Community 2022), but the assembly produced by the compiler puts all the string constants in the `_DATA` segment, rather than a `CONST` segment as referenced in the code. This caused string inlining not to work using the masm_shc utility. When I switched `CONST` to `_DATA`, string inlining worked again.

Thanks for your work on this, the paper was super informative.